### PR TITLE
Fix/set breaks

### DIFF
--- a/src/Components/SessionSetup.jsx
+++ b/src/Components/SessionSetup.jsx
@@ -177,35 +177,43 @@ function SessionSetup() {
 
   return (
     <div className="flex flex-col font-mono bg-[#FFF3DA] p-0 min-h-screen">
+  <div className="sticky top-0 z-50">
     <Navbar />
-    <div className="flex min-h-screen">
-      <SidePanel/>
-      <div className="flex flex-col items-center justify-center w-full p-4">
-        <div className="p-6">
-          {/* Main Box in the Center */}
-          <div className="mb-8">
+  </div>
+  <div className="flex min-h-screen">
+    <div className="fixed left-0">
+      <SidePanel />
+    </div>
+    <div className="flex flex-col items-center justify-center w-full p-4">
+      <div className="p-6">
+        {/* Main Box in the Center */}
+        <div className="mb-8">
+          {/* Ensure proper spacing for the content */}
+          <div className="max-w-screen-md mx-auto">
             {steps[currentStep]}
           </div>
+        </div>
 
-          {/* Navigation Buttons */}
-          <div className="flex justify-between">
-            <button
-              className="bg-purple-500 text-white px-4 py-2 rounded-md"
-              onClick={handlePreviousClick}
-            >
-              Previous
-            </button>
-            <button
-              className="bg-purple-500 text-white px-4 py-2 rounded-md"
-              onClick={handleNextClick}
-            >
-              {currentStep === steps.length - 1 ? "Start Session" : "Next"}
-            </button>
-          </div>
+        {/* Navigation Buttons */}
+        <div className="flex justify-between py-12 p-3">
+          <button
+            className="bg-purple-500 text-white px-4 py-2 rounded-md"
+            onClick={handlePreviousClick}
+          >
+            Previous
+          </button>
+          <button
+            className="bg-purple-500 text-white px-4 py-2 rounded-md"
+            onClick={handleNextClick}
+          >
+            {currentStep === steps.length - 1 ? "Start Session" : "Next"}
+          </button>
         </div>
       </div>
     </div>
   </div>
+</div>
+
   );
 }
 

--- a/src/Components/SessionSetupComponents/SetBreaks.jsx
+++ b/src/Components/SessionSetupComponents/SetBreaks.jsx
@@ -72,7 +72,7 @@ const SetBreaks = () => {
 
   return (
     <div>
-      <h2>SetBreaks</h2>
+      <h2 className="text-center text-2xl font-bold">SetBreaks</h2>
       {/* Grid */}
       <div
         style={{

--- a/src/Components/SessionSetupComponents/SetBreaks.jsx
+++ b/src/Components/SessionSetupComponents/SetBreaks.jsx
@@ -48,7 +48,7 @@ const SetBreaks = () => {
   };
 
   const getNumsForTimeline = () => {
-    let num = localSessionDuration.hours;
+    let num = Number(localSessionDuration.hours);
     if (localSessionDuration.minutes != 0) {
       num += 1;
     }

--- a/src/Components/SessionSetupComponents/SetMusic.jsx
+++ b/src/Components/SessionSetupComponents/SetMusic.jsx
@@ -202,7 +202,7 @@ function SetMusic({ sessionDuration }) {
       <div className="w-full text-center mb-2 mt-0">
         <h2 className="text-3xl font-bold text-black">Sounds</h2>
       </div>
-      <div className="grid grid-cols-2 lg:flex justify-center items-center gap-4">
+      <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
         {soundList.map((file, index) => (
           <div
             key={file.id}
@@ -255,7 +255,7 @@ function SetMusic({ sessionDuration }) {
       <div className="w-full text-center mt-2 mb-0">
         <h2 className="text-3xl font-bold text-black">Effects</h2>
       </div>
-      <div className="grid grid-cols-2 lg:flex justify-center items-center gap-4">
+      <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
         {effectList.map((file, index) => (
           <div
             key={file.id}


### PR DESCRIPTION
**PR Description**

 -  Addressed the issue of viewing 71 grid lines in setBreaks with default time setting and style. Refactored and enhanced the styling in the session-setup based on recent commits.
 -  Optimized the UI layout in the session-setup component for better visual alignment and readability. Implemented improvements such as centered content, enhanced spacing, and streamlined navigation button styling. This update ensures a more polished and user-friendly interface during session setup.

**ScreenShots**
1.![image](https://github.com/nishaYO/StudyBuddy/assets/69946307/0b7fa45d-3c2b-4519-9703-4707831cdcf5)
**SetBreaks with default time**
2.![image](https://github.com/nishaYO/StudyBuddy/assets/69946307/835bdd6c-4daa-41f2-86b1-fe71f0dfe2cb)
**Re arranged the SetMusic Component**